### PR TITLE
Add info and license support

### DIFF
--- a/cocotools/src/argparse.rs
+++ b/cocotools/src/argparse.rs
@@ -21,7 +21,7 @@ pub enum Commands {
         image_folder: PathBuf,
         /// The id of the image to visualize. It is often the same as the filename, but not necessarily.
         #[arg(short, long)]
-        sample_id: Option<u32>,
+        sample_id: Option<u64>,
     },
 
     /// Convert the segmentation format of the labels in a COCO annotation file.

--- a/cocotools/src/coco/object_detection.rs
+++ b/cocotools/src/coco/object_detection.rs
@@ -14,11 +14,32 @@ use crate::utils::load_img;
 use crate::visualize::draw;
 
 /// COCO dataset as-is, without additionnal functionalities.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct Dataset {
+    #[serde(default)]
+    pub info: Info,
     pub images: Vec<Image>,
     pub annotations: Vec<Annotation>,
     pub categories: Vec<Category>,
+    #[serde(default)]
+    pub licenses: Vec<License>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct Info {
+    pub year: u32,
+    pub version: String,
+    pub description: String,
+    pub contributor: String,
+    pub url: String,
+    pub date_created: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct License {
+    pub id: u32,
+    pub name: String,
+    pub url: String,
 }
 
 /// Stores information relating to one image.

--- a/cocotools/src/coco/object_detection.rs
+++ b/cocotools/src/coco/object_detection.rs
@@ -25,7 +25,7 @@ pub struct Dataset {
     pub licenses: Vec<License>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Info {
     pub year: u32,
     pub version: String,
@@ -35,7 +35,7 @@ pub struct Info {
     pub date_created: String,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct License {
     pub id: u32,
     pub name: String,

--- a/cocotools/src/coco/object_detection.rs
+++ b/cocotools/src/coco/object_detection.rs
@@ -47,7 +47,7 @@ pub struct License {
     feature = "pyo3",
     pyclass(get_all, set_all, module = "rpycocotools.anns")
 )]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Image {
     pub id: u64,
     pub width: u32,

--- a/cocotools/src/coco/object_detection.rs
+++ b/cocotools/src/coco/object_detection.rs
@@ -49,14 +49,18 @@ pub struct License {
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Image {
-    pub id: u32,
+    pub id: u64,
     pub width: u32,
     pub height: u32,
     pub file_name: String,
-    // "license": int,
-    // "flickr_url": str,
-    // "coco_url": str,
-    // "date_captured": datetime,
+    #[serde(default)]
+    pub license: u32,
+    #[serde(default)]
+    pub flickr_url: String,
+    #[serde(default)]
+    pub coco_url: String,
+    #[serde(default)]
+    pub date_captured: String,
 }
 
 /// Object instance annotation for object detection.\
@@ -71,8 +75,8 @@ pub struct Image {
 )]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Annotation {
-    pub id: u32,
-    pub image_id: u32,
+    pub id: u64,
+    pub image_id: u64,
     pub category_id: u32,
     /// Segmentation in the annotation file can be a polygon, RLE or COCO RLE.\
     /// Examples of what each segmentation should look like in the JSON file:
@@ -193,12 +197,12 @@ pub struct Category {
 /// This struct provides methods to make working with the dataset easier and more efficient.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct HashmapDataset {
-    pub(crate) anns: HashMap<u32, Annotation>,
+    pub(crate) anns: HashMap<u64, Annotation>,
     cats: HashMap<u32, Category>,
-    imgs: HashMap<u32, Image>,
+    imgs: HashMap<u64, Image>,
     /// Hashmap that links an image id to the image's annotations
     // Use Rc to reference the annotations directly ?
-    img_to_anns: HashMap<u32, HashSet<u32>>,
+    img_to_anns: HashMap<u64, HashSet<u64>>,
     pub image_folder: PathBuf,
 }
 
@@ -234,16 +238,16 @@ impl HashmapDataset {
             .map(|category| (category.id, category))
             .collect();
 
-        let imgs: HashMap<u32, Image> = dataset
+        let imgs: HashMap<u64, Image> = dataset
             .images
             .clone()
             .into_iter()
             .map(|image| (image.id, image))
             .collect();
 
-        let mut anns: HashMap<u32, Annotation> = HashMap::new();
+        let mut anns: HashMap<u64, Annotation> = HashMap::new();
         // Have (at least) an empty set for each image to avoid getting an error in the case where an image does not have any annotation.
-        let mut img_to_anns: HashMap<u32, HashSet<u32>> = dataset
+        let mut img_to_anns: HashMap<u64, HashSet<u64>> = dataset
             .images
             .into_iter()
             .map(|image| (image.id, HashSet::new()))
@@ -287,7 +291,7 @@ impl HashmapDataset {
     /// # Errors
     ///
     /// Will return `Err` if there is no entry in the dataset corresponding to `ann_id`.
-    pub fn get_ann(&self, ann_id: u32) -> Result<&Annotation, MissingIdError> {
+    pub fn get_ann(&self, ann_id: u64) -> Result<&Annotation, MissingIdError> {
         self.anns
             .get(&ann_id)
             .ok_or(MissingIdError::Annotation(ann_id))
@@ -321,7 +325,7 @@ impl HashmapDataset {
     /// # Errors
     ///
     /// Will return `Err` if there is no entry corresponding to `img_id`.
-    pub fn get_img(&self, img_id: u32) -> Result<&Image, MissingIdError> {
+    pub fn get_img(&self, img_id: u64) -> Result<&Image, MissingIdError> {
         self.imgs.get(&img_id).ok_or(MissingIdError::Image(img_id))
     }
 
@@ -336,7 +340,7 @@ impl HashmapDataset {
     /// # Errors
     ///
     /// Will return `Err` if there is no entry corresponding to `img_id`.
-    pub fn get_img_anns(&self, img_id: u32) -> Result<Vec<&Annotation>, MissingIdError> {
+    pub fn get_img_anns(&self, img_id: u64) -> Result<Vec<&Annotation>, MissingIdError> {
         self.img_to_anns
             .get(&img_id)
             .map_or(Err(MissingIdError::Image(img_id)), |ann_ids| {
@@ -351,7 +355,7 @@ impl HashmapDataset {
     /// Will return `Err` if there is no image or annotation entry for `img_id`. Or if the segmentation annotations could not be decompressed.
     pub fn draw_img_anns(
         &self,
-        img_id: u32,
+        img_id: u64,
         draw_bbox: bool,
     ) -> Result<image::ImageBuffer<image::Rgb<u8>, Vec<u8>>, errors::CocoError> {
         let img_path = self.image_folder.join(&self.get_img(img_id)?.file_name);
@@ -410,6 +414,7 @@ impl From<&HashmapDataset> for Dataset {
             images: dataset.get_imgs().into_iter().cloned().collect(),
             annotations: dataset.get_anns().into_iter().cloned().collect(),
             categories: dataset.get_cats().into_iter().cloned().collect(),
+            ..Default::default()
         }
     }
 }

--- a/cocotools/src/coco/pyo3.rs
+++ b/cocotools/src/coco/pyo3.rs
@@ -7,8 +7,8 @@ use crate::coco::object_detection::*;
 impl Annotation {
     #[new]
     fn new(
-        id: u32,
-        image_id: u32,
+        id: u64,
+        image_id: u64,
         category_id: u32,
         segmentation: Segmentation,
         area: f64,
@@ -92,12 +92,13 @@ impl Category {
 #[pymethods]
 impl Image {
     #[new]
-    fn new(id: u32, width: u32, height: u32, file_name: String) -> Self {
+    fn new(id: u64, width: u32, height: u32, file_name: String) -> Self {
         Self {
             id,
             width,
             height,
             file_name,
+            ..Default::default()
         }
     }
 

--- a/cocotools/src/errors.rs
+++ b/cocotools/src/errors.rs
@@ -7,11 +7,11 @@ use thiserror::Error;
 #[derive(thiserror::Error)]
 pub enum MissingIdError {
     #[error("The following annotation id was not found in the dataset: `{0}`.")]
-    Annotation(u32),
+    Annotation(u64),
     #[error("The following category id was not found in the dataset: `{0}`.")]
     Category(u32),
     #[error("The following image id was not found in the dataset: `{0}`.")]
-    Image(u32),
+    Image(u64),
     // #[error(transparent)]
     // InvalidValue(#[from] anyhow::Error),
 }

--- a/cocotools/src/visualize/display.rs
+++ b/cocotools/src/visualize/display.rs
@@ -13,7 +13,7 @@ use crate::utils;
 /// # Errors
 ///
 /// Will return `Err` if `img_id` is not present in the dataset.
-pub fn img_anns(dataset: &HashmapDataset, img_id: u32) -> Result<(), Box<dyn std::error::Error>> {
+pub fn img_anns(dataset: &HashmapDataset, img_id: u64) -> Result<(), Box<dyn std::error::Error>> {
     let anns = dataset.get_img_anns(img_id)?;
     let img_name = &dataset.get_img(img_id)?.file_name;
     let img_path = dataset.image_folder.join(img_name);

--- a/rpycocotools/src/coco.rs
+++ b/rpycocotools/src/coco.rs
@@ -36,7 +36,7 @@ impl PyCOCO {
         self.0.get_imgs().len()
     }
 
-    fn get_img(&self, py: Python<'_>, img_id: u32) -> PyResult<Py<object_detection::Image>> {
+    fn get_img(&self, py: Python<'_>, img_id: u64) -> PyResult<Py<object_detection::Image>> {
         Py::new(
             py,
             self.0
@@ -46,7 +46,7 @@ impl PyCOCO {
         )
     }
 
-    fn get_ann(&self, py: Python<'_>, ann_id: u32) -> PyResult<Py<object_detection::Annotation>> {
+    fn get_ann(&self, py: Python<'_>, ann_id: u64) -> PyResult<Py<object_detection::Annotation>> {
         Py::new(
             py,
             self.0
@@ -93,7 +93,7 @@ impl PyCOCO {
 
     fn get_img_anns(
         &self,
-        img_id: u32,
+        img_id: u64,
         py: Python<'_>,
     ) -> PyResult<Vec<Py<object_detection::Annotation>>> {
         self.0
@@ -109,7 +109,7 @@ impl PyCOCO {
     /// ## Errors
     ///
     /// Will return `Err` if the image cannot be drawn (potentially due to it not being in the dataset) or cannot be displayed.
-    pub fn visualize_img(&self, img_id: u32) -> PyResult<()> {
+    pub fn visualize_img(&self, img_id: u64) -> PyResult<()> {
         let img = self
             .0
             .draw_img_anns(img_id, true)
@@ -138,7 +138,7 @@ impl PyCOCO {
     pub fn draw_anns<'a>(
         &self,
         py: Python<'a>,
-        img_id: u32,
+        img_id: u64,
         draw_bboxes: bool,
     ) -> PyResult<&'a PyArray3<u8>> {
         let img = self
@@ -181,6 +181,7 @@ pub fn from_dataset(
         images,
         annotations,
         categories,
+        ..Default::default()
     };
     let dataset = COCO::from_dataset(dataset, image_folder_path).map_err(PyLoadingError::from)?;
     Ok(PyCOCO(dataset))


### PR DESCRIPTION
Changes to allow deserializing datasets containing `licenses` and `info` fields (they are simply discarded).